### PR TITLE
Fix KeyError when displaying errors from a celery task

### DIFF
--- a/provider/tasks.py
+++ b/provider/tasks.py
@@ -183,10 +183,10 @@ def get_full_course_config(api_user_id, course_id, has_radar_config=True):
         exercises = response.get("exercises", [])
     except APIAuthException:
         exercises = []
-        result["errors"].append("This user does not have correct credentials to use the API of %s" % repr(course))
+        result.setdefault("errors", []).append("This user does not have correct credentials to use the API of %s" % repr(course))
 
     if not exercises:
-        result["errors"].append("No exercises found for %s" % repr(course))
+        result.setdefault("errors", []).append("No exercises found for %s" % repr(course))
 
     if has_radar_config:
         # Exercise API data is expected to contain Radar configurations


### PR DESCRIPTION
# Description

Fixes the following error that occurs when `get_full_course_config` task fails to fetch course data:

```python
Apr 28 14:41:35 hostname radar_celery_main[421877]: [2021-04-28 11:41:35,176: INFO/MainProcess] Received task: provider.tasks.get_full_course_config[29d8f62b-8ee0-42e8-86af-564262bd83f6]
Apr 28 14:41:35 hostname radar_celery_main[421900]: [2021-04-28 11:41:35,381: ERROR/ForkPoolWorker-1] Task provider.tasks.get_full_course_config[29d8f62b-8ee0-42e8-86af-564262bd83f6] raised unexpected: KeyError('errors')
Apr 28 14:41:35 hostname radar_celery_main[421900]: Traceback (most recent call last):
Apr 28 14:41:35 hostname radar_celery_main[421900]:   File "/srv/radar/venv/lib/python3.8/site-packages/celery/app/trace.py", line 405, in trace_task
Apr 28 14:41:35 hostname radar_celery_main[421900]:     R = retval = fun(*args, **kwargs)
Apr 28 14:41:35 hostname radar_celery_main[421900]:   File "/srv/radar/venv/lib/python3.8/site-packages/celery/app/trace.py", line 697, in __protected_call__
Apr 28 14:41:35 hostname radar_celery_main[421900]:     return self.run(*args, **kwargs)
Apr 28 14:41:35 hostname radar_celery_main[421900]:   File "/srv/radar/radar/provider/tasks.py", line 189, in get_full_course_config
Apr 28 14:41:35 hostname radar_celery_main[421900]:     result["errors"].append("No exercises found for %s" % repr(course))
Apr 28 14:41:35 hostname radar_celery_main[421900]: KeyError: 'errors'
```

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested fetching course data in a test environment and inspected the `radar_celery_main` log.

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*