### PR TITLE
Added missing 'provider' in settings

### DIFF
--- a/radar/settings.py
+++ b/radar/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = (
     'django_lti_login',
     'ltilogin',
     'debug_toolbar',
+    'provider',
 )
 
 MIDDLEWARE = (


### PR DESCRIPTION
Fix an issue of celery not finding tasks contained in 'provider'.