### PR TITLE
Fix exercise name assignment in loadsubmissions function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ tokenizer/scalariform/project/project/target/
 __pycache__
 *.pyc
 *.pdf
+
+dolos-proxy
+package-lock.json
+package.json
+*.Identifier
+settings.json
+temp_submission_files/

--- a/data/management/commands/loadsubmissions.py
+++ b/data/management/commands/loadsubmissions.py
@@ -42,6 +42,10 @@ class Command(BaseCommand):
         exercise = course.get_exercise(exercise_key)
         self.stdout.write("Inserting to exercise %s" % (exercise))
 
+        if exercise.name == 'unknown':
+            exercise.name = exercise_key
+            exercise.save()
+
         for path in options['submission_path']:
             submission = load_submission_dir(exercise, path)
             if submission is not None:


### PR DESCRIPTION
Loadsubmissions creates courses and exercises with the name 'unknown' #58

# Description

**What?**

Added an if statement to the loadsubmissions function that checks if exercise name is 'unknown' and changes it to the value from input.

**Why?**

Help with development

**How?**

[ANSWER HERE]

Fixes #58 


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Ran Radar locally and checked the places that showed unknown before. Those places now display the exercise name.

**Did you test the changes in**

- [X] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
